### PR TITLE
add dry_run mode, support deleting group registered runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ cleanup-gitlab-runner is built to run in a CI environment (e.g. GitLab CI).
 
 cleanup-gitlab-runner takes the following environment variables:
 
-| Variable       | Description                                 | Example                      |
-| :------------- | :------------------------------------------ | :--------------------------- |
-| `VERIFY_SSL`   | Verify ssl certificate (defaults to `true`) | `true` or `false`            |
-| `GITLAB_TOKEN` | GitLab access token (more detail see below) | `12345678`                   |
-| `GITLAB_URL`   | GitLab URL (defaults to `CI_SERVER_URL`     | `https://gitlab.example.com` |
+| Variable                   | Description                                                             | Example                      |
+| :------------------------- | :---------------------------------------------------------------------- | :--------------------------- |
+| `VERIFY_SSL`               | Verify ssl certificate (defaults to `true`)                             | `true` or `false`            |
+| `GITLAB_TOKEN`             | GitLab access token (more detail see below)                             | `12345678`                   |
+| `GITLAB_URL`               | GitLab URL (defaults to `CI_SERVER_URL`                                 | `https://gitlab.example.com` |
+| `DRY_RUN`                  | optional, if set it will only print but not delete                      | `true` or `false`            |
+| `GITLAB_GROUP`             | optional, if set only deletes runner registered on the given group id   | `123`                        |
+| `GITLAB_BASEAUTH_USER`     | optional, user for additional basic authentification                    | `my_user`                    |
+| `GITLAB_BASEAUTH_PASSWORD` | optional, password for additional basic authentification                | `my_password`                |
 
 *GITLAB_TOKEN*
 *Create the access token with an admin user*


### PR DESCRIPTION
 i added following features to support my usescases
 
 * dry run mode (DRY_RUN)
 * optional basic auth credentials
 * optional giving in a group id to delete runners registered on the specific group (thats interesting if you own a group but not the gitlab)